### PR TITLE
:wrench: Pin to php 7.0 ATM

### DIFF
--- a/7/zts/alpine/Dockerfile
+++ b/7/zts/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-zts-alpine
+FROM php:7.0-zts-alpine
 
 MAINTAINER Sébastien HOUZÉ <sebastien.houze@verylastroom.com>
 

--- a/7/zts/vendor/karibbu/Dockerfile
+++ b/7/zts/vendor/karibbu/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-zts-alpine
+FROM php:7.0-zts-alpine
 
 MAINTAINER Sébastien HOUZÉ <sebastien.houze@verylastroom.com>
 


### PR DESCRIPTION
As many of our projects still use an incompatible release of atoum with php 7.1 (waiting for atoum 3.0)